### PR TITLE
refactor: Remove the use of sdk LegacyMsg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Improvements
+
+* [93](https://github.com/cosmos/rosetta/pull/93) Removes the use of `LegacyMsg.GetSigners()` in favor of `codec.GetMsgV1Signers`.
+
 ## [v0.50.4](https://github.com/cosmos/rosetta/releases/tag/v0.50.4) 2024-02-26
 
 ### Improvements

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ build:
 plugin:
 	cd plugins/cosmos-hub && make plugin
 
+plugin-debug:
+	cd plugins/cosmos-hub && make plugin-debug
+
 docker:
 	docker build . --tag rosetta
 

--- a/converter.go
+++ b/converter.go
@@ -245,7 +245,7 @@ func (c converter) Ops(status string, msg protov2.Message) ([]*rosettatypes.Oper
 		return nil, crgerrs.WrapError(crgerrs.ErrConverter, fmt.Sprintf("while getting meta from message %s", err.Error()))
 	}
 
-	signers, err := c.cdc.InterfaceRegistry().SigningContext().GetSigners(msg)
+	signers, err := c.cdc.GetMsgV2Signers(msg)
 	if err != nil {
 		return nil, err
 	}

--- a/converter.go
+++ b/converter.go
@@ -163,7 +163,7 @@ func (c converter) UnsignedTx(ops []*rosettatypes.Operation) (tx authsigning.Tx,
 
 		signers, _, err := c.cdc.GetMsgV1Signers(msg)
 		if err != nil {
-			return nil, err
+			return nil, crgerrs.WrapError(crgerrs.ErrConverter, fmt.Sprintf("while getting msg signers %s", err.Error()))
 		}
 
 		// check if there are enough signers
@@ -243,12 +243,15 @@ func (c converter) Ops(status string, msg sdk.Msg) ([]*rosettatypes.Operation, e
 
 	signers, _, err := c.cdc.GetMsgV1Signers(msg)
 	if err != nil {
-		return nil, err
+		return nil, crgerrs.WrapError(crgerrs.ErrConverter, fmt.Sprintf("while getting msg signers in Ops %s", err.Error()))
 	}
 
 	ops := make([]*rosettatypes.Operation, len(signers))
 	for i, signer := range signers {
-		addr, _ := c.cdc.InterfaceRegistry().SigningContext().AddressCodec().BytesToString(signer)
+		addr, err := c.ir.SigningContext().AddressCodec().BytesToString(signer)
+		if err != nil {
+			return nil, crgerrs.WrapError(crgerrs.ErrConverter, fmt.Sprintf("while getting address from signer %s", err.Error()))
+		}
 		op := &rosettatypes.Operation{
 			Type:     sdk.MsgTypeURL(msg),
 			Status:   &status,

--- a/converter_test.go
+++ b/converter_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cosmos/rosetta"
 	crgerrs "github.com/cosmos/rosetta/lib/errors"
 
+	bankv1 "cosmossdk.io/api/cosmos/bank/v1beta1"
+	v1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
 	rosettatypes "github.com/coinbase/rosetta-sdk-go/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/stretchr/testify/suite"
@@ -56,40 +58,40 @@ func (s *ConverterTestSuite) SetupTest() {
 	s.unsignedTx = builder.GetTx()
 }
 
-// func (s *ConverterTestSuite) TestFromRosettaOpsToTxSuccess() {
-//	addr1 := sdk.AccAddress("address1").String()
-//	addr2 := sdk.AccAddress("address2").String()
-//
-//	msg1 := &bank.MsgSend{
-//		FromAddress: addr1,
-//		ToAddress:   addr2,
-//		Amount:      sdk.NewCoins(sdk.NewInt64Coin("test", 10)),
-//	}
-//
-//	msg2 := &bank.MsgSend{
-//		FromAddress: addr2,
-//		ToAddress:   addr1,
-//		Amount:      sdk.NewCoins(sdk.NewInt64Coin("utxo", 10)),
-//	}
-//
-//	ops, err := s.c.ToRosetta().Ops("", msg1)
-//	s.Require().NoError(err)
-//
-//	ops2, err := s.c.ToRosetta().Ops("", msg2)
-//	s.Require().NoError(err)
-//
-//	ops = append(ops, ops2...)
-//
-//	tx, err := s.c.ToSDK().UnsignedTx(ops)
-//	s.Require().NoError(err)
-//
-//	getMsgs := tx.GetMsgs()
-//
-//	s.Require().Equal(2, len(getMsgs))
-//
-//	s.Require().Equal(getMsgs[0], msg1)
-//	s.Require().Equal(getMsgs[1], msg2)
-//}
+func (s *ConverterTestSuite) TestFromRosettaOpsToTxSuccess() {
+	addr1 := sdk.AccAddress("address1").String()
+	addr2 := sdk.AccAddress("address2").String()
+
+	msg1 := &bankv1.MsgSend{
+		FromAddress: addr1,
+		ToAddress:   addr2,
+		Amount:      []*v1beta1.Coin{{Amount: "100", Denom: "test"}},
+	}
+
+	msg2 := &bankv1.MsgSend{
+		FromAddress: addr2,
+		ToAddress:   addr1,
+		Amount:      []*v1beta1.Coin{{Amount: "10", Denom: "utxo"}},
+	}
+
+	ops, err := s.c.ToRosetta().Ops("", msg1)
+	s.Require().NoError(err)
+
+	ops2, err := s.c.ToRosetta().Ops("", msg2)
+	s.Require().NoError(err)
+
+	ops = append(ops, ops2...)
+
+	tx, err := s.c.ToSDK().UnsignedTx(ops)
+	s.Require().NoError(err)
+
+	getMsgs := tx.GetMsgs()
+
+	s.Require().Equal(2, len(getMsgs))
+
+	s.Require().Equal(getMsgs[0], msg1)
+	s.Require().Equal(getMsgs[1], msg2)
+}
 
 func (s *ConverterTestSuite) TestFromRosettaOpsToTxErrors() {
 	s.Run("unrecognized op", func() {

--- a/converter_test.go
+++ b/converter_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/cosmos/rosetta"
 	crgerrs "github.com/cosmos/rosetta/lib/errors"
 
-	bankv1 "cosmossdk.io/api/cosmos/bank/v1beta1"
-	v1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
 	rosettatypes "github.com/coinbase/rosetta-sdk-go/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/stretchr/testify/suite"
@@ -62,16 +60,16 @@ func (s *ConverterTestSuite) TestFromRosettaOpsToTxSuccess() {
 	addr1 := sdk.AccAddress("address1").String()
 	addr2 := sdk.AccAddress("address2").String()
 
-	msg1 := &bankv1.MsgSend{
+	msg1 := &bank.MsgSend{
 		FromAddress: addr1,
 		ToAddress:   addr2,
-		Amount:      []*v1beta1.Coin{{Amount: "100", Denom: "test"}},
+		Amount:      sdk.NewCoins(sdk.NewInt64Coin("test", 10)),
 	}
 
-	msg2 := &bankv1.MsgSend{
+	msg2 := &bank.MsgSend{
 		FromAddress: addr2,
 		ToAddress:   addr1,
-		Amount:      []*v1beta1.Coin{{Amount: "10", Denom: "utxo"}},
+		Amount:      sdk.NewCoins(sdk.NewInt64Coin("utxo", 10)),
 	}
 
 	ops, err := s.c.ToRosetta().Ops("", msg1)

--- a/plugins/cosmos-hub/makefile
+++ b/plugins/cosmos-hub/makefile
@@ -2,3 +2,6 @@
 
 plugin:
 	go build -buildmode=plugin -o main.so main.go
+
+plugin-debug:
+	go build -buildmode=plugin -gcflags="all=-N -l" -o main.so main.go


### PR DESCRIPTION
Closes:
#98 

This PR replaces the use of `sdk.LegacyMsg.GetSigners()` in favor of `codec.GetMsgV1Signers`.
