### PR TITLE
fix: update blockTxs to correctly parse finalizeblock events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* [123](https://github.com/cosmos/rosetta/pull/123) Correctly parse cometBFT finalize block.
+
 ## [v0.50.6](https://github.com/cosmos/rosetta/releases/tag/v0.50.6) 2024-04-23
 
 ### Improvements

--- a/client_online.go
+++ b/client_online.go
@@ -352,7 +352,7 @@ func (c *Client) GetUnconfirmedTx(ctx context.Context, hash string) (*rosettatyp
 	default:
 		return nil, crgerrs.WrapError(crgerrs.ErrBadArgument, fmt.Sprintf("unrecognized tx size: %d", len(hashAsBytes)))
 	case FinalizeBlockTxSize:
-		return nil, crgerrs.WrapError(crgerrs.ErrBadArgument, "endblock and begin block txs cannot be unconfirmed")
+		return nil, crgerrs.WrapError(crgerrs.ErrBadArgument, "finalize block txs cannot be unconfirmed")
 	case DeliverTxSize:
 		break
 	}

--- a/client_online.go
+++ b/client_online.go
@@ -496,7 +496,7 @@ func (c *Client) blockTxs(ctx context.Context, height *int64) (crgtypes.BlockTra
 		return crgtypes.BlockTransactionsResponse{}, crgerrs.WrapError(crgerrs.ErrOnlineClient, "block results transactions do now match block transactions")
 	}
 	// process begin and end block txs
-	FinalizeBlockTx := &rosettatypes.Transaction{
+	finalizeBlockTx := &rosettatypes.Transaction{
 		TransactionIdentifier: &rosettatypes.TransactionIdentifier{Hash: c.converter.ToRosetta().FinalizeBlockTxHash(blockInfo.BlockID.Hash)},
 		Operations: AddOperationIndexes(
 			nil,
@@ -516,7 +516,7 @@ func (c *Client) blockTxs(ctx context.Context, height *int64) (crgtypes.BlockTra
 
 	finalTxs := make([]*rosettatypes.Transaction, 0, 1+len(deliverTx))
 	finalTxs = append(finalTxs, deliverTx...)
-	finalTxs = append(finalTxs, FinalizeBlockTx)
+	finalTxs = append(finalTxs, finalizeBlockTx)
 
 	return crgtypes.BlockTransactionsResponse{
 		BlockResponse: c.converter.ToRosetta().BlockResponse(blockInfo),

--- a/converter.go
+++ b/converter.go
@@ -473,8 +473,8 @@ func AddOperationIndexes(msgOps, balanceOps []*rosettatypes.Operation) (finalOps
 }
 
 // FinalizeBlockTxHash produces a mock beginblock hash that rosetta can query
-// for beginblock operations, it also serves the purpose of representing
-// part of the state changes happening at beginblock level (balance ones)
+// for finalizeBlock operations, it also serves the purpose of representing
+// part of the state changes happening at finalizeblock level (balance ones)
 func (c converter) FinalizeBlockTxHash(hash []byte) string {
 	final := append([]byte{FinalizeBlockHashStart}, hash...)
 	return fmt.Sprintf("%X", final)

--- a/converter.go
+++ b/converter.go
@@ -54,9 +54,7 @@ type ToRosettaConverter interface {
 	// BlockResponse returns a block response given a result block
 	BlockResponse(block *tmcoretypes.ResultBlock) crgtypes.BlockResponse
 	// BeginBlockToTx converts the given begin block hash to rosetta transaction hash
-	BeginBlockTxHash(blockHash []byte) string
-	// EndBlockTxHash converts the given endblock hash to rosetta transaction hash
-	EndBlockTxHash(blockHash []byte) string
+	FinalizeBlockTxHash(blockHash []byte) string
 	// Amounts converts sdk.Coins to rosetta.Amounts
 	Amounts(ownedCoins []sdk.Coin, availableCoins sdk.Coins) []*rosettatypes.Amount
 	// Ops converts an sdk.Msg to rosetta operations
@@ -474,35 +472,25 @@ func AddOperationIndexes(msgOps, balanceOps []*rosettatypes.Operation) (finalOps
 	return finalOps
 }
 
-// EndBlockTxHash produces a mock endblock hash that rosetta can query
-// for endblock operations, it also serves the purpose of representing
-// part of the state changes happening at endblock level (balance ones)
-func (c converter) EndBlockTxHash(hash []byte) string {
-	final := append([]byte{EndBlockHashStart}, hash...)
-	return fmt.Sprintf("%X", final)
-}
-
-// BeginBlockTxHash produces a mock beginblock hash that rosetta can query
+// FinalizeBlockTxHash produces a mock beginblock hash that rosetta can query
 // for beginblock operations, it also serves the purpose of representing
 // part of the state changes happening at beginblock level (balance ones)
-func (c converter) BeginBlockTxHash(hash []byte) string {
-	final := append([]byte{BeginBlockHashStart}, hash...)
+func (c converter) FinalizeBlockTxHash(hash []byte) string {
+	final := append([]byte{FinalizeBlockHashStart}, hash...)
 	return fmt.Sprintf("%X", final)
 }
 
 // HashToTxType takes the provided hash bytes from rosetta and discerns if they are
-// a deliver tx type or endblock/begin block hash, returning the real hash afterwards
+// a deliver tx type or finalize block hash, returning the real hash afterward
 func (c converter) HashToTxType(hashBytes []byte) (txType TransactionType, realHash []byte) {
 	switch len(hashBytes) {
 	case DeliverTxSize:
 		return DeliverTxTx, hashBytes
 
-	case BeginEndBlockTxSize:
+	case FinalizeBlockTxSize:
 		switch hashBytes[0] {
-		case BeginBlockHashStart:
-			return BeginBlockTx, hashBytes[1:]
-		case EndBlockHashStart:
-			return EndBlockTx, hashBytes[1:]
+		case FinalizeBlockHashStart:
+			return FinalizeBlockHashStart, hashBytes[1:]
 		default:
 			return UnrecognizedTx, nil
 		}

--- a/converter_test.go
+++ b/converter_test.go
@@ -179,23 +179,23 @@ func (s *ConverterTestSuite) TestOpsAndSigners() {
 	})
 }
 
-func (s *ConverterTestSuite) TestBeginEndBlockAndHashToTxType() {
+func (s *ConverterTestSuite) TestFinalizeBlockHashToTxType() {
 	const deliverTxHex = "5229A67AA008B5C5F1A0AEA77D4DEBE146297A30AAEF01777AF10FAD62DD36AB"
 
 	deliverTxBytes, err := hex.DecodeString(deliverTxHex)
 	s.Require().NoError(err)
 
-	endBlockTxHex := s.c.ToRosetta().FinalizeBlockTxHash(deliverTxBytes)
+	finalizeBlockTxHex := s.c.ToRosetta().FinalizeBlockTxHash(deliverTxBytes)
 
 	txType, hash := s.c.ToSDK().HashToTxType(deliverTxBytes)
 
 	s.Require().Equal(rosetta.DeliverTxTx, txType)
 	s.Require().Equal(deliverTxBytes, hash, "deliver tx hash should not change")
 
-	endBlockTxBytes, err := hex.DecodeString(endBlockTxHex)
+	finalizeBlockTxBytes, err := hex.DecodeString(finalizeBlockTxHex)
 	s.Require().NoError(err)
 
-	txType, hash = s.c.ToSDK().HashToTxType(endBlockTxBytes)
+	txType, hash = s.c.ToSDK().HashToTxType(finalizeBlockTxBytes)
 	s.Require().Equal(rosetta.FinalizeBlockTx, txType)
 	s.Require().Equal(deliverTxBytes, hash, "end block tx hash should be equal to a block hash")
 

--- a/converter_test.go
+++ b/converter_test.go
@@ -185,8 +185,7 @@ func (s *ConverterTestSuite) TestBeginEndBlockAndHashToTxType() {
 	deliverTxBytes, err := hex.DecodeString(deliverTxHex)
 	s.Require().NoError(err)
 
-	endBlockTxHex := s.c.ToRosetta().EndBlockTxHash(deliverTxBytes)
-	beginBlockTxHex := s.c.ToRosetta().BeginBlockTxHash(deliverTxBytes)
+	endBlockTxHex := s.c.ToRosetta().FinalizeBlockTxHash(deliverTxBytes)
 
 	txType, hash := s.c.ToSDK().HashToTxType(deliverTxBytes)
 
@@ -197,17 +196,8 @@ func (s *ConverterTestSuite) TestBeginEndBlockAndHashToTxType() {
 	s.Require().NoError(err)
 
 	txType, hash = s.c.ToSDK().HashToTxType(endBlockTxBytes)
-
-	s.Require().Equal(rosetta.EndBlockTx, txType)
+	s.Require().Equal(rosetta.FinalizeBlockTx, txType)
 	s.Require().Equal(deliverTxBytes, hash, "end block tx hash should be equal to a block hash")
-
-	beginBlockTxBytes, err := hex.DecodeString(beginBlockTxHex)
-	s.Require().NoError(err)
-
-	txType, hash = s.c.ToSDK().HashToTxType(beginBlockTxBytes)
-
-	s.Require().Equal(rosetta.BeginBlockTx, txType)
-	s.Require().Equal(deliverTxBytes, hash, "begin block tx hash should be equal to a block hash")
 
 	txType, hash = s.c.ToSDK().HashToTxType([]byte("invalid"))
 

--- a/types.go
+++ b/types.go
@@ -17,10 +17,9 @@ const (
 // which are not represented as transactions we mock only the balance changes
 // happening at those levels as transactions. (check BeginBlockTxHash for more info)
 const (
-	DeliverTxSize       = sha256.Size
-	BeginEndBlockTxSize = DeliverTxSize + 1
-	EndBlockHashStart   = 0x0
-	BeginBlockHashStart = 0x1
+	DeliverTxSize          = sha256.Size
+	FinalizeBlockTxSize    = DeliverTxSize + 1
+	FinalizeBlockHashStart = 0x1
 )
 
 const (
@@ -37,8 +36,7 @@ type TransactionType int
 
 const (
 	UnrecognizedTx TransactionType = iota
-	BeginBlockTx
-	EndBlockTx
+	FinalizeBlockTx
 	DeliverTxTx
 )
 


### PR DESCRIPTION
Closes:
#121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Consolidated transaction processing stages into a single `FinalizeBlockTx` process.
	- Renamed relevant transaction types and constants to align with the new `FinalizeBlockTx` terminology.

- **Bug Fixes**
	- Corrected the `cometBFT` finalize block parsing in the changelog documentation.

- **Tests**
	- Updated test suite to reflect changes in transaction processing terminology and logic.

- **Documentation**
	- Updated all relevant comments and logic descriptions to reflect the new transaction processing model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->