### PR TITLE
refactor: grpc insecure plus plugin not mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Improvements
+
+* [#157](https://github.com/cosmos/rosetta/pull/157) Rosetta can now run without requiring a plugin.
+
 ## [v0.50.10](https://github.com/cosmos/rosetta/releases/tag/v0.50.10) 2024-09-25
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#157](https://github.com/cosmos/rosetta/pull/157) Rosetta can now run without requiring a plugin.
 
+### Bug Fixes
+
+* [#157](https://github.com/cosmos/rosetta/pull/157) Added support for insecure connections to gRPC reflection servers.
+
 ## [v0.50.10](https://github.com/cosmos/rosetta/releases/tag/v0.50.10) 2024-09-25
 
 ### Improvements

--- a/cmd/rosetta.go
+++ b/cmd/rosetta.go
@@ -29,16 +29,18 @@ func RosettaCommand(ir codectypes.InterfaceRegistry, cdc codec.Codec) *cobra.Com
 			}
 			conf.WithCodec(ir, protoCodec)
 
-			err = rosetta.LoadPlugin(ir, cmd.Flag("plugin").Value.String())
-			if err != nil {
-				fmt.Printf("[Rosetta]- Error while loading cosmos-hub plugin: %s", err.Error())
-				return err
-			}
-
-			if cmd.Flag("grpc-types-server").Value.String() != "" {
-				err = rosetta.ReflectInterfaces(ir, cmd.Flag("grpc-types-server").Value.String())
+			pluginPath := cmd.Flag(rosetta.FlagPlugin).Value.String()
+			typesServer := cmd.Flag(rosetta.FlagGRPCTypesServerEndpoint).Value.String()
+			if pluginPath != "" {
+				err = rosetta.LoadPlugin(ir, pluginPath)
 				if err != nil {
-					fmt.Printf("[Rosetta]- Error while reflecting from grpc server: %s", err.Error())
+					fmt.Printf("[Rosetta]- Error while loading plugin: %s", err.Error())
+					return err
+				}
+			} else if typesServer != "" {
+				err = rosetta.ReflectInterfaces(ir, typesServer)
+				if err != nil {
+					fmt.Printf("[Rosetta]- Error while reflecting from gRPC server: %s", err.Error())
 					return err
 				}
 			}

--- a/config.go
+++ b/config.go
@@ -306,5 +306,5 @@ func SetFlags(flags *pflag.FlagSet) {
 	flags.Int(FlagGasToSuggest, clientflags.DefaultGasLimit, "default gas for fee suggestion")
 	flags.String(FlagDenomToSuggest, DenomToSuggest, "default denom for fee suggestion")
 	flags.String(FlagPricesToSuggest, DefaultPrices, "default prices for fee suggestion")
-	flags.String(FlagPlugin, DefaultPlugin, "plugin folder name")
+	flags.String(FlagPlugin, "", "plugin folder name")
 }

--- a/config.go
+++ b/config.go
@@ -49,8 +49,6 @@ const (
 	DenomToSuggest = "uatom"
 	// DefaultPrices defines the default list of prices to suggest
 	DefaultPrices = "1uatom,1stake"
-	// DefaultPlugin define plugin location for interface and type registry
-	DefaultPlugin = "cosmos-hub"
 )
 
 // configuration flags


### PR DESCRIPTION
This PR enables:
1. Rosetta can now run without requiring a plugin.
2. Added support for insecure connections to gRPC reflection servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Rosetta can now operate without requiring a plugin.
	- Added support for insecure connections to gRPC reflection servers.

- **Bug Fixes**
	- Improved error handling and messaging for plugin loading and gRPC server reflection.

- **Chores**
	- Updated the changelog to reflect recent improvements and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->