### PR TITLE
Docs: Fix typo:  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ An implementation example can be found in `simapp` package.
 
 To run Rosetta in your application CLI, use the following command:
 
-> **Note:** if using the native approach, add your node name before any rosetta comand.
+> **Note:** if using the native approach, add your node name before any rosetta command.
 
 ```shell
 rosetta --help


### PR DESCRIPTION
### Title
**Fix typo: comand → command in README.md**

### Description
This pull request corrects a typo in the README file:

- Fixed "comand" to "command" for improved clarity and professionalism.

---

### Diff
```diff
- > **Note:** if using the native approach, add your node name before any rosetta comand.
+ > **Note:** if using the native approach, add your node name before any rosetta command.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a minor typographical error in the README, correcting "rosetta comand" to "rosetta command"
  - No functional changes to the document's content or instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->