### PR TITLE
Docs: Typo fix  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ rosetta
 
 ## Plugins - Multi chain connections
 
-Rosetta will try to reflect the node types trough reflection over the node gRPC endpoints, there may be cases were this approach is not enough. It is possible to extend or implement the required types easily trough plugins.
+Rosetta will try to reflect the node types trough reflection over the node gRPC endpoints, there may be cases were this approach is not enough. It is possible to extend or implement the required types easily through plugins.
 
 To use Rosetta over any chain, it is required to set up prefixes and registering zone specific interfaces through plugins.
 


### PR DESCRIPTION
Fixed a typo in README.md, changing "trough" to "through" for improved accuracy and readability. Ensured the documentation maintains a professional tone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a typo in the README, correcting "throug" to "through" for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->